### PR TITLE
Fix sticky header by enabling vertical scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 
       .table-container {
         overflow-x: hidden;
-        overflow-y: visible;
+        overflow-y: auto;
         position: relative;
         border-radius: 8px;
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -1085,7 +1085,7 @@
       /* Estilos para o freeze das primeiras colunas */
       .table-container {
         overflow-x: hidden;
-        overflow-y: visible;
+        overflow-y: auto;
         position: relative;
         border-radius: 8px;
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- allow sticky headers by enabling vertical scrolling in `.table-container`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68815a72cd5c832caf01e56e92f4c1d6